### PR TITLE
Migrate runner image to 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,30 +10,13 @@ on:
 jobs:
   build_amd64:
     name: Build NekOS (x86_64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Free up GitHub runner space
         run: ./.github/gh-action-free-space.sh
-
-      # This is deeply cursed and creates a frankenbuntu, but it works
-      # and we need to do it to get a newer version of Podman that
-      # actually supports heredocs (allows us to borrow from StageX's
-      # upstream Containerfiles without rewriting them)
-      #
-      # The version shipped in 24.04 should support them really, but
-      # Canonical have patched it out:
-      #   https://github.com/containers/buildah/issues/5474#issuecomment-2058440179
-      #
-      # This fix can be retired when GitHub update the `ubuntu-latest`
-      # runner to Ubuntu 26.04
-      - name: Install Podman from Ubuntu 25.04
-        run: |
-          sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu plucky main universe" > /etc/apt/sources.list.d/plucky.list'
-          sudo apt update
-          sudo apt install -y podman conmon crun runc
 
       - name: Install pytest
         run: |
@@ -53,23 +36,13 @@ jobs:
 
   build_arm64:
     name: Build NekOS (aarch64)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Free up GitHub runner space
         run: ./.github/gh-action-free-space.sh
-
-      # Note the subtle difference between this and the amd64 version!
-      #
-      # For aarch64 packages, we need to use ports.ubuntu.com rather than
-      # archive.ubuntu.com
-      - name: Install Podman from Ubuntu 25.04
-        run: |
-          sudo sh -c 'echo "deb http://ports.ubuntu.com/ubuntu-ports plucky main universe" > /etc/apt/sources.list.d/plucky.list'
-          sudo apt update
-          sudo apt install -y podman conmon crun runc
 
       - name: Install pytest
         run: |


### PR DESCRIPTION
This removes the deeply cursed frankenbuntu thing I had going on that was pulling Podman from 25.04 into the 24.04 base.